### PR TITLE
Add system design, schema, API spec, and seed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,103 @@
-# prompt-generator1
-Система за генериране на промптове за работни листове
+# Prompt Generator Platform
+
+Системен дизайн и артефакти за платформа за създаване и управление на промптове за образователни ресурси.
+
+## Съдържание
+- [Визия и архитектура](#визия-и-архитектура)
+- [База данни](#база-данни)
+- [API спецификация](#api-спецификация)
+- [Seed скрипт](#seed-скрипт)
+- [Локална среда](#локална-среда)
+- [Master Prompt](#master-prompt)
+
+## Визия и архитектура
+Общата концепция, архитектурни слоеве, ERD описание, тестова стратегия и пътна карта са описани в [docs/system-design.md](docs/system-design.md).
+
+## База данни
+Първоначалната PostgreSQL схема и индекси са дефинирани в [db/migrations/0001_init.sql](db/migrations/0001_init.sql). Миграцията създава всички основни таблици, енум типове и индекси за производителност и отчетност.
+
+## API спецификация
+OpenAPI 3.0 спецификацията на REST API е достъпна в [openapi/prompt-generator.yaml](openapi/prompt-generator.yaml). Файлът може да се импортира в Swagger UI/Postman за генериране на клиентски SDK-та и документация.
+
+## Seed скрипт
+Примерен seed скрипт с Prisma се намира в [scripts/seed.ts](scripts/seed.ts). Той създава Super Admin потребител, базови каталози и одобрен шаблон за работен лист по история.
+
+## Локална среда
+1. Създайте `.env` с настройки за база данни и JWT тайни.
+2. Стартирайте инфраструктурата с Docker Compose (PostgreSQL, API, Frontend). Примерен `docker-compose.yml`:
+   ```yaml
+   version: '3.8'
+   services:
+     db:
+       image: postgres:15
+       restart: unless-stopped
+       environment:
+         POSTGRES_DB: prompt_generator
+         POSTGRES_USER: prompt
+         POSTGRES_PASSWORD: prompt
+       ports:
+         - '5432:5432'
+       volumes:
+         - pgdata:/var/lib/postgresql/data
+     api:
+       build: ./backend
+       depends_on:
+         - db
+       environment:
+         DATABASE_URL: postgresql://prompt:prompt@db:5432/prompt_generator
+       ports:
+         - '4000:4000'
+     web:
+       build: ./frontend
+       depends_on:
+         - api
+       ports:
+         - '5173:5173'
+   volumes:
+     pgdata:
+   ```
+3. Изпълнете миграциите (`npx prisma migrate deploy` или `alembic upgrade head`).
+4. Пуснете seed скрипта: `npx ts-node scripts/seed.ts`.
+5. Стартирайте API и SPA, след което отворете `http://localhost:5173`.
+
+## Master Prompt
+Използвайте следния промпт, когато искате разработващ ИИ да генерира архитектура или код за системата:
+
+```
+ROLE: Ти си старши софтуерен архитект и full-stack разработчик.
+GOAL: Проектирај и опиши/генерирай код за система „Prompt Generator“ с Админ панел, REST API и База данни, според спецификацията по-долу.
+STACK (предложение):
+
+Backend: Node.js (NestJS/Express) или Python (FastAPI), JWT Auth, Zod/ Pydantic валидации.
+
+DB: PostgreSQL + Prisma/SQLAlchemy, миграции.
+
+Frontend: React + TypeScript, Vite, Zustand/Redux, Tailwind.
+
+Docs: OpenAPI/Swagger.
+CORE FEATURES:
+
+Админ: каталози (roles, tasks, formats, dimensions), шаблони с плейсхолдъри, версии, одобрения, аудит.
+
+Потребител: зареждане на каталози, избор на шаблон, попълване на параметри (вкл. свободен текст, markdown, линкове с URL валидация), „Генерирай промпт“, преглед, копиране, експорт (.md/.txt/.json).
+
+API: /catalog/*, /templates, /generate, /presets, /user-configs, /audit.
+
+Сигурност: RBAC, rate limiting, input sanitize, MFA за админ.
+DATA MODEL: използвай таблиците и полетата от раздел „База данни“ (горе), с релации и индекси; добави placeholder_definitions с тип/валидации/по подразбиране.
+VALIDATION: URL regex, дължини, enum стойности; сървърът отказва невалидни стойности.
+OUTPUTS:
+
+ERD диаграма (текстово описание).
+
+SQL миграции за PostgreSQL.
+
+OpenAPI спецификация за основните маршрути.
+
+Примерен seed script (роля, задача, формат, 1 шаблон „Работен лист по история“).
+
+Frontend: страници /admin/* и /generator, компоненти за динамични форми според placeholder_definitions.
+
+Тестове (unit + e2e) и инструкции за локално стартиране (Docker Compose).
+QUALITY GATES: покритие ≥80%, ESLint/Prettier, CI pipeline. Предай финален README с инструкции.
+```

--- a/db/migrations/0001_init.sql
+++ b/db/migrations/0001_init.sql
@@ -1,0 +1,175 @@
+-- PostgreSQL initial schema for Prompt Generator
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "citext";
+
+CREATE TYPE user_role AS ENUM ('super_admin', 'admin', 'editor', 'viewer', 'api_client');
+CREATE TYPE template_status AS ENUM ('draft', 'in_review', 'approved', 'deprecated');
+CREATE TYPE placeholder_type AS ENUM (
+    'string',
+    'text',
+    'markdown',
+    'enum',
+    'multiselect',
+    'tags',
+    'url',
+    'url_list',
+    'number',
+    'boolean'
+);
+
+CREATE TABLE users (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    email CITEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    full_name TEXT NOT NULL,
+    role user_role NOT NULL,
+    mfa_secret TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE api_tokens (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    token_hash TEXT NOT NULL,
+    expires_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, name)
+);
+
+CREATE TABLE roles (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL UNIQUE,
+    description TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE tasks (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL,
+    description TEXT,
+    subject TEXT NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (name, subject)
+);
+
+CREATE TABLE formats (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL UNIQUE,
+    mime TEXT NOT NULL,
+    extension TEXT NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE dimensions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,
+    choices_json JSONB,
+    validators_json JSONB,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (name, type)
+);
+
+CREATE TABLE templates (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL,
+    description TEXT,
+    content_md TEXT NOT NULL,
+    status template_status NOT NULL DEFAULT 'draft',
+    version INTEGER NOT NULL DEFAULT 1,
+    changelog TEXT DEFAULT '',
+    created_by UUID REFERENCES users(id),
+    updated_by UUID REFERENCES users(id),
+    approved_by UUID REFERENCES users(id),
+    approved_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (name, version)
+);
+
+CREATE TABLE template_placeholder_definitions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    template_id UUID NOT NULL REFERENCES templates(id) ON DELETE CASCADE,
+    placeholder_key TEXT NOT NULL,
+    placeholder_type placeholder_type NOT NULL,
+    label TEXT NOT NULL,
+    description TEXT,
+    is_required BOOLEAN NOT NULL DEFAULT FALSE,
+    default_value_json JSONB,
+    options_json JSONB,
+    validators_json JSONB,
+    order_index INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (template_id, placeholder_key)
+);
+
+CREATE TABLE template_relations (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    template_id UUID NOT NULL REFERENCES templates(id) ON DELETE CASCADE,
+    role_id UUID REFERENCES roles(id),
+    task_id UUID REFERENCES tasks(id),
+    format_id UUID REFERENCES formats(id)
+);
+
+CREATE TABLE presets (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    template_id UUID NOT NULL REFERENCES templates(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    description TEXT,
+    meta_json JSONB NOT NULL,
+    created_by UUID REFERENCES users(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (template_id, name)
+);
+
+CREATE TABLE user_configs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    template_id UUID NOT NULL REFERENCES templates(id) ON DELETE CASCADE,
+    name TEXT,
+    values_json JSONB NOT NULL,
+    is_favorite BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE generated_prompts (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    template_id UUID REFERENCES templates(id) ON DELETE SET NULL,
+    values_json JSONB NOT NULL,
+    output_md TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE audit_logs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    entity TEXT NOT NULL,
+    entity_id UUID,
+    action TEXT NOT NULL,
+    before_json JSONB,
+    after_json JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_roles_active ON roles (is_active);
+CREATE INDEX idx_tasks_active ON tasks (is_active);
+CREATE INDEX idx_formats_active ON formats (is_active);
+CREATE INDEX idx_dimensions_active ON dimensions (is_active);
+CREATE INDEX idx_templates_status ON templates (status);
+CREATE INDEX idx_template_placeholders_template ON template_placeholder_definitions (template_id, order_index);
+CREATE INDEX idx_template_relations_lookup ON template_relations (role_id, task_id, format_id);
+CREATE INDEX idx_user_configs_user ON user_configs (user_id, created_at DESC);
+CREATE INDEX idx_generated_prompts_user ON generated_prompts (user_id, created_at DESC);
+CREATE INDEX idx_audit_logs_entity ON audit_logs (entity, entity_id);

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -1,0 +1,114 @@
+# Prompt Generator System Design
+
+## Vision Overview
+- **Purpose:** Provide a unified platform for designing, governing, and reusing high-quality prompts tailored for educational resources, starting with Bulgarian History worksheets.
+- **Key Goals:**
+  - Consistent, reusable prompt patterns across curricula and creators.
+  - Full lifecycle governance with versioning, approvals, and auditability.
+  - Fast, teacher-friendly UX with presets and history for rapid reuse.
+  - Extensible taxonomy and template model that can scale to new subjects, grades, and output formats.
+
+## High-Level Architecture
+The solution follows a three-tier architecture:
+
+1. **Frontend SPA (React + TypeScript + Vite):**
+   - Routes for `/admin/*` and `/generator`.
+   - Uses Zustand for lightweight state management.
+   - Tailwind CSS for rapid UI development and accessibility compliance.
+   - Communicates with the API through a typed client generated from the OpenAPI spec.
+
+2. **Backend API (NestJS + TypeScript):**
+   - Modular structure (`AuthModule`, `CatalogModule`, `TemplatesModule`, `GeneratorModule`, `AuditModule`, etc.).
+   - Uses Prisma ORM for PostgreSQL persistence and Zod for runtime validation.
+   - Implements RBAC with JWT tokens, MFA for administrators, and rate limiting via NestJS guards.
+   - Exposes REST endpoints aligned with the OpenAPI contract and serves Swagger UI for documentation.
+
+3. **Data Layer (PostgreSQL):**
+   - Normalized schema mirroring the taxonomy and template structure.
+   - Row-level versioning for templates with lifecycle states (Draft → Review → Approved → Deprecated).
+   - Audit log captures before/after snapshots for traceability.
+
+Supporting components include:
+- **Background workers** for generating exports (Docx/HTML) and sending notifications when templates reach approval.
+- **CI/CD pipeline** executing linting, unit/integration/E2E tests, and database migrations via Prisma.
+- **Observability stack** (Prometheus + Grafana + Loki) for metrics, tracing, and logs.
+
+## ERD (Textual Description)
+- `users (id, email, password_hash, full_name, role, mfa_secret, is_active, created_at, updated_at)`
+  - `role` is an enum: `super_admin`, `admin`, `editor`, `viewer`, `api_client`.
+  - One-to-many relationship to `audit_logs`, `templates` (`created_by`, `updated_by`), and `user_configs`.
+- `roles (id, name, description, is_active, created_at, updated_at)`
+  - Linked to `template_relations` (role_id) and `presets` metadata.
+- `tasks (id, name, description, subject, is_active, created_at, updated_at)`
+  - Linked to `template_relations` (task_id).
+- `formats (id, name, mime, extension, is_active, created_at, updated_at)`
+  - Linked to `template_relations` (format_id) and referenced inside placeholder definitions.
+- `dimensions (id, name, type, choices_json, validators_json, is_active, created_at, updated_at)`
+  - Provide Bloom levels, grades, duration, etc.
+- `templates (id, name, description, content_md, status, version, created_by, updated_by, approved_by, approved_at, changelog, created_at, updated_at)`
+  - `status` enum: `draft`, `in_review`, `approved`, `deprecated`.
+  - Has many `template_placeholder_definitions` and `template_relations` records.
+- `template_placeholder_definitions (id, template_id, placeholder_key, placeholder_type, label, description, is_required, default_value_json, options_json, validators_json, order_index, created_at)`
+  - Describes each placeholder (string, enum, multiselect, url_list, markdown, etc.).
+- `template_relations (id, template_id, role_id, task_id, format_id)`
+  - Many-to-one to `templates`, `roles`, `tasks`, `formats`.
+- `presets (id, name, description, meta_json, template_id, created_by, created_at)`
+  - `meta_json` stores pre-configured placeholder values and recommended dimension selections.
+- `user_configs (id, user_id, template_id, name, values_json, is_favorite, created_at)`
+  - Records history of generated prompts and favorites.
+- `generated_prompts (id, user_id, template_id, values_json, output_md, created_at)`
+  - Immutable record for auditability and analytics.
+- `audit_logs (id, user_id, entity, entity_id, action, before_json, after_json, created_at)`
+  - Captures CRUD actions across administrative resources.
+- `api_tokens (id, user_id, name, token_hash, expires_at, created_at)`
+  - Supports optional API clients with revocable access.
+
+## Data Flow Summary
+1. Admin defines catalog entries (roles, tasks, formats, dimensions).
+2. Admin drafts a template with placeholder definitions → submits for review.
+3. Second admin reviews, comments, and approves; template status changes to `approved` and becomes selectable.
+4. Editor/Teacher opens generator UI, selects template or preset, fills dynamic form generated from placeholder definitions.
+5. API validates inputs against placeholder validators, composes prompt sections, stores generated prompt, and returns final text plus metadata.
+6. User can export, copy, or bookmark configuration; audit log records actions.
+
+## Security & Compliance Considerations
+- **Authentication:** OAuth2 password or SSO (SAML) integration; JWT access tokens with refresh flow.
+- **Authorization:** NestJS Guards enforce RBAC per route and per resource; database-level constraints ensure only approved templates are exposed.
+- **MFA:** Time-based OTP required for Super Admins and Admins.
+- **Input Validation:** Zod schemas derived from placeholder definitions; server rejects invalid URLs, lengths, or enum values.
+- **Rate Limiting:** Leaky bucket per user/IP; stricter limits for API clients.
+- **Auditing:** All admin actions logged; tamper-resistant logs forwarded to SIEM.
+- **Compliance:** GDPR-compliant data retention, PII minimization, export/delete endpoints for user configs.
+
+## UX Highlights
+- Four-step generator wizard with live preview panel updating as users fill fields.
+- Accessible components (ARIA roles, keyboard shortcuts, high contrast themes).
+- Presets presented as "recipes" cards with quick load.
+- Inline validation and helper tooltips pulled from placeholder definitions.
+- One-click export buttons for Markdown, TXT, JSON; copy-to-clipboard with toast confirmation.
+
+## Testing Strategy
+- **Unit Tests:**
+  - Placeholder validation schema builder.
+  - Template lifecycle transitions and RBAC guards.
+- **Integration/API Tests:**
+  - Catalog endpoints contract tests.
+  - `/api/generate` validation and output structure.
+- **E2E Tests (Playwright/Cypress):**
+  - Admin creates template → reviewer approves → teacher generates prompt.
+  - Accessibility suite with Lighthouse score ≥ 90.
+- **Security Tests:**
+  - Automated dependency scanning, static analysis, and OWASP ZAP baseline scan.
+
+## Deployment & Operations
+- Dockerized services orchestrated via `docker-compose` for local dev and Helm charts for production.
+- CI pipeline (GitHub Actions) executes lint, tests, coverage (≥80%), and builds Docker images.
+- Monitoring via OpenTelemetry traces, Prometheus metrics, Grafana dashboards, and Loki logs.
+- Nightly backups of PostgreSQL; point-in-time recovery configured.
+
+## Roadmap (from specification)
+- **v1:** Core catalogs, single template, prompt generation, favorites, RBAC, audit logs.
+- **v1.1:** Full versioning workflow with review/approval and diffing.
+- **v1.2:** Presets, history UI, DOCX/HTML exports.
+- **v1.3:** Organizations/teams with shared template libraries.
+- **v2:** Public template marketplace and API key management.

--- a/openapi/prompt-generator.yaml
+++ b/openapi/prompt-generator.yaml
@@ -1,0 +1,681 @@
+openapi: 3.0.3
+info:
+  title: Prompt Generator API
+  version: 1.0.0
+  description: REST API for managing prompt templates and generating educational prompts.
+servers:
+  - url: https://api.prompt-generator.local
+    description: Production server
+  - url: http://localhost:4000
+    description: Local development server
+security:
+  - bearerAuth: []
+
+paths:
+  /api/auth/login:
+    post:
+      summary: Authenticate user and obtain JWT tokens
+      tags: [Auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email, password]
+              properties:
+                email:
+                  type: string
+                  format: email
+                password:
+                  type: string
+      responses:
+        '200':
+          description: Authentication successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accessToken:
+                    type: string
+                  refreshToken:
+                    type: string
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+
+  /api/catalog/roles:
+    get:
+      summary: List available roles
+      tags: [Catalog]
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CatalogItem'
+  /api/catalog/tasks:
+    get:
+      summary: List available tasks
+      tags: [Catalog]
+      parameters:
+        - in: query
+          name: subject
+          schema:
+            type: string
+          description: Filter by subject (e.g. HistoryBG)
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TaskItem'
+  /api/catalog/formats:
+    get:
+      summary: List available output formats
+      tags: [Catalog]
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FormatItem'
+  /api/catalog/dimensions:
+    get:
+      summary: List taxonomy dimensions
+      tags: [Catalog]
+      parameters:
+        - in: query
+          name: type
+          schema:
+            type: string
+          description: Filter by dimension type (e.g. bloom, grade)
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DimensionItem'
+
+  /api/templates:
+    get:
+      summary: List templates
+      tags: [Templates]
+      parameters:
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [draft, in_review, approved, deprecated]
+        - in: query
+          name: roleId
+          schema:
+            type: string
+            format: uuid
+        - in: query
+          name: taskId
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TemplateSummary'
+    post:
+      summary: Create a template (admin only)
+      tags: [Templates]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TemplateCreateRequest'
+      responses:
+        '201':
+          description: Template created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TemplateDetail'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+
+  /api/templates/{id}:
+    get:
+      summary: Get template detail
+      tags: [Templates]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Template detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TemplateDetail'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      summary: Update template (admin)
+      tags: [Templates]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TemplateId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TemplateUpdateRequest'
+      responses:
+        '200':
+          description: Template updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TemplateDetail'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/templates/{id}/status:
+    post:
+      summary: Transition template status (review/approve/deprecate)
+      tags: [Templates]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TemplateId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status:
+                  type: string
+                  enum: [draft, in_review, approved, deprecated]
+                comment:
+                  type: string
+      responses:
+        '200':
+          description: Status updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TemplateDetail'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/generate:
+    post:
+      summary: Generate prompt output
+      tags: [Generator]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [templateId, values]
+              properties:
+                templateId:
+                  type: string
+                  format: uuid
+                values:
+                  type: object
+                  additionalProperties: true
+      responses:
+        '200':
+          description: Generated prompt
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  templateId:
+                    type: string
+                    format: uuid
+                  version:
+                    type: integer
+                  output:
+                    type: string
+                  placeholders:
+                    type: object
+                    additionalProperties: true
+                  metadata:
+                    type: object
+                    properties:
+                      generatedAt:
+                        type: string
+                        format: date-time
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/presets:
+    get:
+      summary: List presets
+      tags: [Presets]
+      parameters:
+        - in: query
+          name: templateId
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Preset list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PresetSummary'
+    post:
+      summary: Create preset (admin)
+      tags: [Presets]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PresetCreateRequest'
+      responses:
+        '201':
+          description: Preset created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PresetSummary'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+
+  /api/user-configs:
+    get:
+      summary: List user configurations (favorites/history)
+      tags: [UserConfigs]
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Config list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserConfig'
+    post:
+      summary: Save user configuration
+      tags: [UserConfigs]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserConfigCreateRequest'
+      responses:
+        '201':
+          description: Configuration saved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserConfig'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/audit:
+    get:
+      summary: List audit logs (admin only)
+      tags: [Audit]
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: entity
+          schema:
+            type: string
+        - in: query
+          name: entityId
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Audit log entries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AuditLog'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    TemplateId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    UnauthorizedError:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    ForbiddenError:
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    BadRequest:
+      description: Invalid request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+  schemas:
+    CatalogItem:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        isActive:
+          type: boolean
+    TaskItem:
+      allOf:
+        - $ref: '#/components/schemas/CatalogItem'
+        - type: object
+          properties:
+            subject:
+              type: string
+    FormatItem:
+      allOf:
+        - $ref: '#/components/schemas/CatalogItem'
+        - type: object
+          properties:
+            mime:
+              type: string
+            extension:
+              type: string
+    DimensionItem:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        type:
+          type: string
+        choices:
+          type: array
+          items:
+            type: string
+        validators:
+          type: object
+    TemplateSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        status:
+          type: string
+          enum: [draft, in_review, approved, deprecated]
+        version:
+          type: integer
+        updatedAt:
+          type: string
+          format: date-time
+    TemplateCreateRequest:
+      type: object
+      required: [name, contentMd, placeholderDefinitions]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        contentMd:
+          type: string
+        relations:
+          type: object
+          properties:
+            roleIds:
+              type: array
+              items:
+                type: string
+                format: uuid
+            taskIds:
+              type: array
+              items:
+                type: string
+                format: uuid
+            formatIds:
+              type: array
+              items:
+                type: string
+                format: uuid
+        placeholderDefinitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlaceholderDefinition'
+    TemplateUpdateRequest:
+      allOf:
+        - $ref: '#/components/schemas/TemplateCreateRequest'
+      properties:
+        status:
+          type: string
+          enum: [draft, in_review, approved, deprecated]
+        changelog:
+          type: string
+    TemplateDetail:
+      allOf:
+        - $ref: '#/components/schemas/TemplateSummary'
+        - type: object
+          properties:
+            contentMd:
+              type: string
+            placeholderDefinitions:
+              type: array
+              items:
+                $ref: '#/components/schemas/PlaceholderDefinition'
+            relations:
+              type: object
+              properties:
+                roles:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/CatalogItem'
+                tasks:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/TaskItem'
+                formats:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/FormatItem'
+    PlaceholderDefinition:
+      type: object
+      required: [key, type, label]
+      properties:
+        key:
+          type: string
+        type:
+          type: string
+          enum: [string, text, markdown, enum, multiselect, tags, url, url_list, number, boolean]
+        label:
+          type: string
+        description:
+          type: string
+        isRequired:
+          type: boolean
+        defaultValue:
+          nullable: true
+        options:
+          type: array
+          items:
+            type: string
+        validators:
+          type: object
+    PresetSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        templateId:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        meta:
+          type: object
+    PresetCreateRequest:
+      type: object
+      required: [templateId, name, meta]
+      properties:
+        templateId:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        meta:
+          type: object
+    UserConfig:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        templateId:
+          type: string
+          format: uuid
+        name:
+          type: string
+        values:
+          type: object
+        isFavorite:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+    UserConfigCreateRequest:
+      type: object
+      required: [templateId, values]
+      properties:
+        templateId:
+          type: string
+          format: uuid
+        name:
+          type: string
+        values:
+          type: object
+        isFavorite:
+          type: boolean
+    AuditLog:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        userId:
+          type: string
+          format: uuid
+        entity:
+          type: string
+        entityId:
+          type: string
+          format: uuid
+        action:
+          type: string
+        before:
+          type: object
+        after:
+          type: object
+        createdAt:
+          type: string
+          format: date-time
+    ErrorResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        code:
+          type: string
+        details:
+          type: object

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,170 @@
+/**
+ * Example seed script using Prisma Client.
+ *
+ * Run with: `npx ts-node scripts/seed.ts`
+ */
+import { PrismaClient, TemplateStatus } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const superAdmin = await prisma.user.upsert({
+    where: { email: 'admin@prompt-generator.local' },
+    update: {},
+    create: {
+      email: 'admin@prompt-generator.local',
+      passwordHash: '$argon2id$v=19$m=65536,t=3,p=4$examplehash',
+      fullName: 'Super Admin',
+      role: 'super_admin',
+      isActive: true,
+    },
+  });
+
+  const historyTeacherRole = await prisma.role.upsert({
+    where: { name: 'History Teacher' },
+    update: {},
+    create: {
+      name: 'History Teacher',
+      description: 'Teacher specializing in Bulgarian History',
+    },
+  });
+
+  const worksheetTask = await prisma.task.upsert({
+    where: { name_subject: { name: 'Worksheet', subject: 'HistoryBG' } },
+    update: {},
+    create: {
+      name: 'Worksheet',
+      subject: 'HistoryBG',
+      description: 'Structured worksheet for Bulgarian history topics',
+    },
+  });
+
+  const markdownFormat = await prisma.format.upsert({
+    where: { name: 'Markdown' },
+    update: {},
+    create: {
+      name: 'Markdown',
+      mime: 'text/markdown',
+      extension: '.md',
+    },
+  });
+
+  const template = await prisma.template.create({
+    data: {
+      name: 'История - Работен лист',
+      description: 'Базов шаблон за работен лист по история на България',
+      contentMd: `ROLE: {{enum:role}}
+GOAL: Създай {{enum:task}} за тема "{{string:topic}}" по {{enum:subject:HistoryBG}} за {{enum:grade}}.
+CONSTRAINTS: Език: {{enum:language:BG,EN}}; Ниво Bloom: {{enum:bloom}}; Продължителност: {{enum:duration}}.
+KEY CONCEPTS: {{tags:concepts[]}}
+MATERIALS: {{url_list:resources[]}} + {{markdown:notes}}
+OUTPUT: Формат {{enum:format}}. Включи секции: {{multiselect:sections[Intro,SourceWork,Map,Argument,SelfAssessment,Rubric]}}.
+STYLE: кратко, ясно, подходящо за Gen Alpha, без лични данни.
+`,
+      status: TemplateStatus.approved,
+      version: 1,
+      createdBy: superAdmin.id,
+      approvedBy: superAdmin.id,
+      approvedAt: new Date(),
+      relations: {
+        create: [
+          {
+            roleId: historyTeacherRole.id,
+            taskId: worksheetTask.id,
+            formatId: markdownFormat.id,
+          },
+        ],
+      },
+      placeholderDefinitions: {
+        create: [
+          {
+            placeholderKey: 'role',
+            placeholderType: 'enum',
+            label: 'Role',
+            description: 'Persona who will execute the prompt',
+            isRequired: true,
+            optionsJson: { values: ['Учител по история', 'AI експерт'] },
+          },
+          {
+            placeholderKey: 'topic',
+            placeholderType: 'string',
+            label: 'Topic',
+            description: 'Specific historical topic (e.g. Иван Асен II)',
+            isRequired: true,
+          },
+          {
+            placeholderKey: 'grade',
+            placeholderType: 'enum',
+            label: 'Grade',
+            optionsJson: { values: ['5', '6', '7'] },
+            isRequired: true,
+          },
+          {
+            placeholderKey: 'language',
+            placeholderType: 'enum',
+            label: 'Language',
+            optionsJson: { values: ['BG', 'EN'] },
+            isRequired: true,
+          },
+          {
+            placeholderKey: 'bloom',
+            placeholderType: 'enum',
+            label: 'Bloom Level',
+            optionsJson: { values: ['Remember', 'Understand', 'Apply', 'Analyze', 'Evaluate', 'Create'] },
+            isRequired: true,
+          },
+          {
+            placeholderKey: 'duration',
+            placeholderType: 'enum',
+            label: 'Duration',
+            optionsJson: { values: ['15 мин', '30 мин', '45 мин'] },
+            isRequired: true,
+          },
+          {
+            placeholderKey: 'concepts',
+            placeholderType: 'tags',
+            label: 'Key Concepts',
+          },
+          {
+            placeholderKey: 'resources',
+            placeholderType: 'url_list',
+            label: 'Resources',
+            validatorsJson: { maxItems: 5 },
+          },
+          {
+            placeholderKey: 'notes',
+            placeholderType: 'markdown',
+            label: 'Teacher Notes',
+          },
+          {
+            placeholderKey: 'sections',
+            placeholderType: 'multiselect',
+            label: 'Sections',
+            optionsJson: { values: ['Intro', 'SourceWork', 'Map', 'Argument', 'SelfAssessment', 'Rubric'] },
+          },
+          {
+            placeholderKey: 'format',
+            placeholderType: 'enum',
+            label: 'Output Format',
+            optionsJson: { values: ['Markdown', 'DOCX', 'HTML'] },
+          },
+        ],
+      },
+    },
+    include: {
+      relations: true,
+      placeholderDefinitions: true,
+    },
+  });
+
+  console.log('Seed completed:', template.id);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- document the target platform vision, architecture, ERD, testing approach, and roadmap
- define the initial PostgreSQL schema and indices for catalogs, templates, and audit logging
- provide an OpenAPI 3 specification and Prisma seed script for the approved history worksheet template
- update the README with usage instructions and the master prompt for downstream AI generation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbca5c4fe48326af63269f1289e826